### PR TITLE
Change to github link on help/about page

### DIFF
--- a/VocaDbWeb/Views/Help/Index.cshtml
+++ b/VocaDbWeb/Views/Help/Index.cshtml
@@ -132,7 +132,7 @@
 		<h4 id="contactus">Contact Us</h4>
 		support[at]vocadb.net<br />
 		<a href="http://www.vocaloidotaku.net/index.php?/topic/25685-vocadb-vocaloid-database" title="">Discussion thread at VocaloidOtaku</a><br />
-		<a href="http://code.google.com/p/vocadb" title="">Google code</a><br />
+		<a href="https://github.com/VocaDB/vocadb" title="">Code on Github</a><br />
 		You can also contact the
 		@Html.ActionLink("moderators", "Index", "User", new { groupId = VocaDb.Model.Domain.Users.UserGroupId.Moderator }, null)
 		or @Html.ActionLink("administrators", "Index", "User", new { groupId = VocaDb.Model.Domain.Users.UserGroupId.Admin }, null)


### PR DESCRIPTION
Change to github link.
Small (and semi unnecessary) change, but I still thought I'd help out.